### PR TITLE
Add static container build

### DIFF
--- a/.containerbuild.sh
+++ b/.containerbuild.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# switch to nightly
+rustup default nightly
+
+# install musl target
+rustup target add x86_64-unknown-linux-musl
+
+# build it
+cargo build --release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM scratch
+
+ADD target/x86_64-unknown-linux-musl/release/rust_membership_api /
+EXPOSE 8000
+
+CMD ["/rust_membership_api"]

--- a/container.sh
+++ b/container.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# We need to use a script to encapsulate our build here
+docker run -v $(pwd):/home/rust/src ekidd/rust-musl-builder bash .containerbuild.sh
+


### PR DESCRIPTION
Use a container with musl libc inside, which can yield Go-style static
binaries for Rust. This allows us to ship containers that contain only
the binary, and not an entire linux distro. We don't want the distro, we
just want the libc.

conatiner.sh runs the musl build inside the musl environment, and leaves
the binary on our local disk. The Dockerfile copies in the binary and
exposes our ports, and yields a small Docker image.